### PR TITLE
Fix package name for other OS'

### DIFF
--- a/aesgcm/file_storage_nacl.go
+++ b/aesgcm/file_storage_nacl.go
@@ -10,7 +10,7 @@
 
 // +build nacl
 
-package storage
+package aesgcm
 
 import (
 	"os"

--- a/aesgcm/file_storage_plan9.go
+++ b/aesgcm/file_storage_plan9.go
@@ -8,7 +8,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-package storage
+package aesgcm
 
 import (
 	"os"

--- a/aesgcm/file_storage_solaris.go
+++ b/aesgcm/file_storage_solaris.go
@@ -10,7 +10,7 @@
 
 // +build solaris
 
-package storage
+package aesgcm
 
 import (
 	"os"

--- a/aesgcm/file_storage_windows.go
+++ b/aesgcm/file_storage_windows.go
@@ -8,7 +8,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-package storage
+package aesgcm
 
 import (
 	"syscall"


### PR DESCRIPTION
The package names are conflicting for other OS' in the aesgcm. This fixes the build on windows, etc.